### PR TITLE
Correct asset save/delete crash

### DIFF
--- a/MakePlugin/Plugins/TutorialPlugin/Source/TutorialPluginEditor/Private/TutorialCustomAssetFactory.cpp
+++ b/MakePlugin/Plugins/TutorialPlugin/Source/TutorialPluginEditor/Private/TutorialCustomAssetFactory.cpp
@@ -11,5 +11,5 @@ UTutorialCustomAssetFactory::UTutorialCustomAssetFactory()
 
 UObject* UTutorialCustomAssetFactory::FactoryCreateNew(UClass* InClass, UObject* InParent, FName InName, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn)
 {
-	return NewObject<UTutorialCustomAsset>(InParent, InClass, InName);
+	return NewObject<UTutorialCustomAsset>(InParent, InClass, InName, Flags);
 }


### PR DESCRIPTION
Engine crash when you try to save or delete newly created TutorialCustomAsset because Flags in UFactory was not passed to NewObject function